### PR TITLE
Fix: Retrieves psychologist's own appointments

### DIFF
--- a/app/Services/Psicologia/AgendamentoService.php
+++ b/app/Services/Psicologia/AgendamentoService.php
@@ -113,7 +113,7 @@ class AgendamentoService
             'remarcacoes'
         ])
         ->where('ID_CLINICA', 1)
-        ->where('ID_PSICOLOGO', $request->input('id_psicologo')) // Retorna apenas agendamentos vinculados ao psicólogo em questão
+        ->where('ID_PSICOLOGO', session('psicologo')[1]) // Retorna apenas agendamentos vinculados ao psicólogo em questão
         ->where('STATUS_AGEND', '<>', 'Excluido');
 
         // Filtro por nome ou CPF do paciente

--- a/resources/views/psicologia/psicologo/consultar_agenda.blade.php
+++ b/resources/views/psicologia/psicologo/consultar_agenda.blade.php
@@ -243,7 +243,7 @@
 
             function carregarAgendamentos() {
                 const params = getFilters();
-                const url = `/psicologo/consultar-agendamento?${params.toString()}`;
+                const url = `/psicologo/consultar-agendamento/buscar?${params.toString()}`;
 
                 // Adiciona um feedback visual de carregamento
                 agendamentosTbody.innerHTML = `<tr><td colspan="13" class="text-center"><div class="spinner-border spinner-border-sm" role="status"><span class="visually-hidden">Loading...</span></div> Carregando...</td></tr>`;

--- a/routes/web.php
+++ b/routes/web.php
@@ -351,7 +351,7 @@ Route::middleware([AuthPsicologoMiddleware::class])->group(function () {
 
     Route::get('/psicologo/consultar-paciente/buscar', [PacienteController::class, 'getPacienteByNameCPFPsicologo'])->name('psicologoGetPaciente');
 
-    Route::get('/psicologo/consultar-agendamento', [AgendamentoController::class, 'getAgendamentosForPsicologo'])->name('getAgendamentosForPsicologo');
+    Route::get('/psicologo/consultar-agendamento/buscar', [AgendamentoController::class, 'getAgendamentosForPsicologo'])->name('getAgendamentosForPsicologo');
 
     Route::get('/psicologo/pesquisar-disciplina', [ServicoController::class, 'getDisciplinaServico'])->name('psicologoGetDisciplina');
 


### PR DESCRIPTION
Fixes an issue where appointments were not correctly filtered for the logged-in psychologist.

Updates the appointment retrieval logic to use the psychologist's session ID instead of a request parameter, ensuring that only the psychologist's own appointments are fetched. Also updates the route for fetching the psychologist's agenda.