### PR TITLE
Feat: Retrieves professor's schedule

### DIFF
--- a/app/Http/Controllers/Psicologia/AgendamentoController.php
+++ b/app/Http/Controllers/Psicologia/AgendamentoController.php
@@ -153,16 +153,15 @@ class AgendamentoController extends Controller
         $turmas = array_column($professor[4], 'TURMA');
 
         $psicologos = DB::table('LYCEUM_BKP_PRODUCAO.dbo.LY_MATRICULA as mat')
-        ->join('FAESA_CLINICA_AGENDAMENTO as ag', 'ag.ALUNO', 'mat.ALUNO')
+        ->join('FAESA_CLINICA_AGENDAMENTO as ag', 'ag.ID_PSICOLOGO', 'mat.ALUNO')
         ->whereIn('mat.TURMA', $turmas)
-        ->select('ag.ID_PSICOLOGO')
-        ->get()->toArray();
+        ->pluck('ag.ID_PSICOLOGO');
 
         $agendamentos = FaesaClinicaAgendamento::with('paciente', 'servico')
         ->where('ID_CLINICA', 1)
         ->where('STATUS_AGEND', '<>', 'Excluido')
         ->where('STATUS_AGEND', '<>', 'Remarcado')
-        ->whereIn('ID_PSICOLOGO', $psicologos ?? null)
+        ->whereIn('ID_PSICOLOGO', $psicologos)
         ->get();
 
         $events = $agendamentos

--- a/routes/web.php
+++ b/routes/web.php
@@ -397,6 +397,8 @@ Route::middleware([AuthProfessorMiddleware::class])->group( function() {
         return view('psicologia.professor.menu_agenda');
     })->name('professorMenu');
 
+    Route::get('/professor/agendamentos-calendar', [AgendamentoController::class, 'getAgendamentosForCalendarProfessor']);
+
     Route::post('/professor/login', function() {
         return view('psicologia.professor.menu_agenda');
     })->name('professorLoginPost');


### PR DESCRIPTION
Adds a route and modifies the query to retrieve the professor's schedule from the database, to show it on the calendar.

It corrects the join condition in the query to properly link `FAESA_CLINICA_AGENDAMENTO` and `LY_MATRICULA` tables using `ID_PSICOLOGO`, and adds a route to fetch the schedule