### PR TITLE
Feat: Adds endpoint to get schedules for professors

### DIFF
--- a/app/Services/Psicologia/AgendamentoService.php
+++ b/app/Services/Psicologia/AgendamentoService.php
@@ -211,7 +211,107 @@ class AgendamentoService
 
     public function getAgendamentosForProfessor(Request $request)
     {
-        
+        $professor = session('professor');
+        $turmas = array_column($professor[4], 'TURMA');
+
+        $psicologos = DB::table('LYCEUM_BKP_PRODUCAO.dbo.LY_MATRICULA as mat')
+        ->join('FAESA_CLINICA_AGENDAMENTO as ag', 'ag.ID_PSICOLOGO', 'mat.ALUNO')
+        ->whereIn('mat.TURMA', $turmas)
+        ->pluck('ag.ID_PSICOLOGO');
+
+        $query = FaesaClinicaAgendamento::with([
+            'paciente',
+            'servico',
+            'clinica',
+            'agendamentoOriginal',
+            'remarcacoes'
+        ])
+        ->where('ID_CLINICA', 1)
+        ->where('STATUS_AGEND', '<>', 'Excluido')
+        ->where('ID_PSICOLOGO', $psicologos);
+
+        // Filtro por nome ou CPF do paciente
+        if ($request->filled('search')) {
+            $search = $request->input('search');
+            $query->whereHas('paciente', function($q) use ($search) {
+                $q->where('NOME_COMPL_PACIENTE', 'like', "%{$search}%")
+                ->orWhere('CPF_PACIENTE', 'like', "%{$search}%");
+            });
+        }
+
+        // FILTRO POR PSICÓLOGO
+        if ($request->filled('psicologo')) {
+            $psicologo = $request->input('psicologo');
+
+            $query->whereHas('psicologo', function($q) use ($psicologo) {
+                $q->where('ALUNO', 'like', "{$psicologo}%")
+                ->orWhere('NOME_COMPL', 'like', "%{$psicologo}%");
+            });
+        }
+
+        // FILTRO POR DATA
+        if ($request->filled('date')) {
+            try {
+                $date = Carbon::parse($request->input('date'))->format('Y-m-d');
+                $query->where('DT_AGEND', $date);
+            } catch (\Exception $e) {
+                // DATA INVÁLIDA - IGNORA FILTRO
+            }
+        }
+
+        // FILTRO POR HORA DE INÍCIO
+        if ($request->filled('start_time')) {
+            try {
+                $startTime = Carbon::createFromFormat('H:i', $request->input('start_time'))->format('H:i:s');
+                $query->where('HR_AGEND_INI', '>=', $startTime);
+            } catch (\Exception $e) {
+                // Hora inválida - ignora filtro
+            }
+        }
+
+        // FILTRO POR HORA DE FIM
+        if ($request->filled('end_time')) {
+            try {
+                $endTime = Carbon::createFromFormat('H:i', $request->input('end_time'))->format('H:i:s');
+                $query->where('HR_AGEND_FIN', '<=', $endTime);
+            } catch (\Exception $e) {
+                // Hora inválida - ignora filtro
+            }
+        }
+
+        // FILTRO POR STATUS
+        if ($request->filled('status')) {
+            $query->where('STATUS_AGEND', $request->input('status'));
+        }
+
+        // FILTRO POR SERVIÇO
+        if ($request->filled('service')) {
+            $service = $request->input('service');
+            $query->whereHas('servico', function($q) use ($service) {
+                $q->where('SERVICO_CLINICA_DESC', 'like', "%{$service}%");
+            });
+        }
+
+        // FILTRO POR VALOR
+        if ($request->filled('valor')) {
+            $valorFormatado = str_replace(',', '.', $request->input('valor'));
+            $query->where('VALOR_AGEND', '=', $valorFormatado);
+        }
+
+        // FILTRO POR LOCAL
+        if ($request->filled('local')) {
+            $local = $request->input('local');
+            $query->where('LOCAL', 'like', "%{$local}%");
+        }
+
+        $query->orderBy('DT_AGEND', 'desc');
+
+        // Limita o número de registros retornados - Limite de 100
+        $limit = min((int) $request->input('limit', 10), 100);
+
+        $agendamentos = $query->limit($limit)->get();
+
+        return response()->json($agendamentos);
     }
 
     public function atualizarAgendamento(array $dados): FaesaClinicaAgendamento

--- a/resources/views/psicologia/professor/consultar_agenda.blade.php
+++ b/resources/views/psicologia/professor/consultar_agenda.blade.php
@@ -60,7 +60,7 @@
 </head>
 
 <body class="bg-body-secondary">
-    @include('components.psicologo_navbar')
+    @include('components.professor_navbar')
 
     @if($errors->any())
         <div class="alert alert-danger shadow text-center position-fixed top-0 start-50 translate-middle-x mt-3 animate-alert" style="max-width: 90%;">

--- a/routes/web.php
+++ b/routes/web.php
@@ -397,7 +397,7 @@ Route::middleware([AuthProfessorMiddleware::class])->group( function() {
         return view('psicologia.professor.menu_agenda');
     })->name('professorMenu');
 
-    Route::get('/professor/agendamentos-calendar', [AgendamentoController::class, 'getAgendamentosForCalendarProfessor']);
+    Route::get('/professor/agendamentos-calendar', [AgendamentoController::class, 'getAgendamentosForCalendarProfessor'])->name('getAgendamentosForCalendarProfessor');
 
     Route::post('/professor/login', function() {
         return view('psicologia.professor.menu_agenda');


### PR DESCRIPTION
Adds a new endpoint to retrieve schedules specifically for professors.

This endpoint filters schedules based on the professor's assigned classes,
allowing them to view appointments related to their students. It also implements
filtering by patient name/CPF, psychologist, date, time, status, service, value and local

Also update professor navbar on view