### PR TITLE
feat: refactors routes and UI for professor and psicologo

### DIFF
--- a/app/Services/Psicologia/AgendamentoService.php
+++ b/app/Services/Psicologia/AgendamentoService.php
@@ -215,7 +215,6 @@ public function getAgendamentosForProfessor(Request $request)
 {
     $professor = session('professor');
     $turmas = array_column($professor[4], 'TURMA');
-
     $psicologos = DB::table('LYCEUM_BKP_PRODUCAO.dbo.LY_MATRICULA as mat')
         ->join('FAESA_CLINICA_AGENDAMENTO as ag', 'ag.ID_PSICOLOGO', 'mat.ALUNO')
         ->whereIn('mat.TURMA', $turmas)
@@ -226,7 +225,8 @@ public function getAgendamentosForProfessor(Request $request)
         'servico',
         'clinica',
         'agendamentoOriginal',
-        'remarcacoes'
+        'remarcacoes',
+        'psicologo'
     ])
         ->where('ID_CLINICA', 1)
         ->where('STATUS_AGEND', '<>', 'Excluido')

--- a/resources/views/components/professor_navbar.blade.php
+++ b/resources/views/components/professor_navbar.blade.php
@@ -184,6 +184,13 @@
             </a>
         </li>
 
+        <!-- CONSULTAR PSICOLOGOS E PACIENTES DOS PSICOLOGOS -->
+        <li class="list-group-item rounded-1 p-0 overflow-hidden ">
+            <a href="/professor/psicologo" class="link-agendar d-flex align-items-center gap-2 p-1">
+                <i class="bi bi-people-fill"></i> Psicologos
+            </a>
+        </li>
+
         <!-- LOGOUT -->
         <li class="list-group-item mt-auto rounded-1 p-0 overflow-hidden ">
             <a href="/logout" class="link-logout d-flex align-items-center gap-2 p-1">
@@ -213,12 +220,6 @@
             <li class="list-group-item p-0 overflow-hidden ">
                 <a href="/psicologia/consultar-agendamento" class="link-agendar d-flex align-items-center gap-2 p-2">
                     <i class="fas fa-edit"></i> Agendas
-                </a>
-            </li>
-            <!-- CONSULTAR PACIENTE -->
-            <li class="list-group-item p-0 overflow-hidden ">
-                <a href="/psicologia/consultar-paciente" class="link-agendar d-flex align-items-center gap-2 p-2">
-                    <i class="bi bi-people"></i> Pacientes
                 </a>
             </li>
             <!-- LOGOUT -->

--- a/resources/views/psicologia/professor/consultar_psicologo.blade.php
+++ b/resources/views/psicologia/professor/consultar_psicologo.blade.php
@@ -1,0 +1,312 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Relatório - Pacientes por Psicólogo</title>
+
+    <link rel="icon" type="image/png" href="/favicon_faesa.png">
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet" />
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/mdb-ui-kit/7.1.0/mdb.min.css" rel="stylesheet" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+
+    <style>
+        .shadow-dark {
+            box-shadow: 0 0.75rem 1.25rem rgba(0,0,0,0.4) !important;
+        }
+
+        @keyframes slideDownFadeOut {
+            0%   { transform: translate(-50%, -100%); opacity: 0; }
+            10%  { transform: translate(-50%, 0); opacity: 1; }
+            90%  { transform: translate(-50%, 0); opacity: 1; }
+            100% { transform: translate(-50%, -100%); opacity: 0; }
+        }
+        .animate-alert {
+            animation: slideDownFadeOut 5s ease forwards;
+            z-index: 1050;
+        }
+
+        /* Mantive seu estilo de botão não-collapsed */
+        .accordion-button:not(.collapsed) {
+            background-color: #e7f1ff;
+            color: #0c63e4;
+        }
+
+        /* Estilos para o accordion custom (animação por max-height) */
+        .accordion-content {
+            max-height: 0;
+            overflow: hidden;
+            transition: max-height 280ms ease;
+        }
+
+        /* Garante que o body interno mantenha padding */
+        .accordion-body {
+            padding: .75rem 1rem;
+        }
+    </style>
+</head>
+
+<body class="bg-body-secondary">
+    @include('components.professor_navbar')
+
+    @if($errors->any())
+        <div class="alert alert-danger shadow text-center position-fixed top-0 start-50 translate-middle-x mt-3 animate-alert" style="max-width: 90%;">
+            <strong>Ops!</strong> Corrija os itens abaixo:
+            <ul class="mb-0 mt-1 list-unstyled">
+                @foreach($errors->all() as $error)
+                    <li><i class="bi bi-exclamation-circle-fill me-1"></i> {{ $error }}</li>
+                @endforeach
+            </ul>
+        </div>
+    @endif
+
+    @if(session('success'))
+        <div class="alert alert-success text-center shadow position-fixed top-0 start-50 translate-middle-x mt-3 animate-alert">
+            {{ session('success') }}
+        </div>
+    @endif
+
+    <div class="container ms-3 mw-100">
+        <div class="row">
+            <x-page-title></x-page-title>
+
+            <div class="col-12 shadow-lg shadow-dark p-4 bg-body-tertiary rounded">
+                <form id="search-form" class="w-100 mb-4">
+                    <div class="row g-3 align-items-end">
+                        <div class="col-12 col-md-6 col-lg-4">
+                            <label for="psicologo-input" class="form-label fw-bold">Filtrar por Psicólogo</label>
+                            <div class="input-group">
+                                <span class="input-group-text"><i class="bi bi-person-workspace"></i></span>
+                                <input id="psicologo-input" name="psicologo" type="search" class="form-control" placeholder="Nome ou Matrícula" />
+                            </div>
+                        </div>
+                        <div class="col-12 col-md-6 col-lg-auto d-flex gap-2">
+                            <button type="submit" class="btn btn-primary"><i class="bi bi-search"></i> Pesquisar</button>
+                            <button type="button" class="btn btn-outline-secondary" id="btnClearFilters">Limpar</button>
+                        </div>
+                    </div>
+                </form>
+
+                <hr>
+
+                <h5 class="mb-3">Resultados Agrupados</h5>
+                <div class="accordion" id="accordionPsicologos"></div>
+
+            </div>
+        </div>
+    </div>
+
+    <!-- Mantive o bundle do Bootstrap (se precisar remover em ambiente de teste para isolar conflitos, veja checklist abaixo) -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+
+    <script>
+        document.addEventListener("DOMContentLoaded", () => {
+            const searchForm = document.getElementById('search-form');
+            const accordionContainer = document.getElementById('accordionPsicologos');
+
+            // Se true => permite múltiplos abertos; se false => um por vez (comportamento "accordion")
+            const allowMultipleOpen = false;
+
+            function getFilters() {
+                const formData = new FormData(searchForm);
+                return new URLSearchParams(formData);
+            }
+
+            function sanitizeId(value) {
+                // Prefixa com 'psicologo-' e troca caracteres não alfanuméricos por underscore
+                return 'psicologo-' + String(value).replace(/[^\w-]/g, '_');
+            }
+
+            function montarItem(psicologo) {
+                const safeId = sanitizeId(psicologo.id);
+
+                let pacientesHtml = '<ul class="list-group list-group-flush">';
+                psicologo.pacientes
+                    .sort((a, b) => a.nome.localeCompare(b.nome, 'pt-BR'))
+                    .forEach(paciente => {
+                        pacientesHtml += `<li class="list-group-item"><strong>${escapeHtml(paciente.nome)}</strong> (CPF: ${escapeHtml(paciente.cpf)})</li>`;
+                    });
+                pacientesHtml += '</ul>';
+
+                const accordionItem = document.createElement('div');
+                accordionItem.className = 'accordion-item';
+
+                accordionItem.innerHTML = `
+                    <h2 class="accordion-header" id="heading-${safeId}">
+                        <button class="accordion-button collapsed d-flex align-items-center" type="button"
+                            aria-expanded="false"
+                            aria-controls="${safeId}">
+                            <strong class="me-3">${escapeHtml(psicologo.nome)}</strong>
+                            <span class="badge bg-primary rounded-pill ms-auto">${psicologo.pacientes.length} Paciente(s)</span>
+                        </button>
+                    </h2>
+
+                    <div id="${safeId}" class="accordion-content" aria-labelledby="heading-${safeId}">
+                        <div class="accordion-body p-0">${pacientesHtml}</div>
+                    </div>
+                `;
+
+                // referencias
+                const btn = accordionItem.querySelector('.accordion-button');
+                const content = accordionItem.querySelector('.accordion-content');
+
+                // inicial state
+                content.style.maxHeight = '0px';
+                content.style.overflow = 'hidden';
+
+                // função de abrir
+                function openItem() {
+                    if (!allowMultipleOpen) {
+                        // fecha os outros
+                        accordionContainer.querySelectorAll('.accordion-content').forEach(c => {
+                            if (c !== content) {
+                                c.style.maxHeight = '0px';
+                                const otherBtn = c.parentElement.querySelector('.accordion-button');
+                                if (otherBtn) {
+                                    otherBtn.classList.add('collapsed');
+                                    otherBtn.setAttribute('aria-expanded', 'false');
+                                }
+                            }
+                        });
+                    }
+
+                    // expande o atual
+                    // ajuste: primeiro remove maxHeight '0px' para obter scrollHeight correto
+                    content.style.maxHeight = content.scrollHeight + 'px';
+                    btn.classList.remove('collapsed');
+                    btn.setAttribute('aria-expanded', 'true');
+                }
+
+                // função de fechar
+                function closeItem() {
+                    content.style.maxHeight = '0px';
+                    btn.classList.add('collapsed');
+                    btn.setAttribute('aria-expanded', 'false');
+                }
+
+                // toggle
+                btn.addEventListener('click', (e) => {
+                    e.preventDefault(); // evita qualquer ação indesejada
+                    const isOpen = btn.getAttribute('aria-expanded') === 'true' || (content.style.maxHeight && content.style.maxHeight !== '0px');
+                    if (isOpen) closeItem();
+                    else openItem();
+                });
+
+                // Corrige altura em resize (se conteúdo mudar de tamanho)
+                window.addEventListener('resize', () => {
+                    if (btn.getAttribute('aria-expanded') === 'true') {
+                        // recalcula para novo scrollHeight
+                        content.style.maxHeight = content.scrollHeight + 'px';
+                    }
+                });
+
+                // Após transição, se abriu, limpa maxHeight para permitir conteúdo fluido (opcional)
+                content.addEventListener('transitionend', () => {
+                    if (btn.getAttribute('aria-expanded') === 'true') {
+                        // mantém um valor suficiente (não remove por segurança)
+                        content.style.maxHeight = content.scrollHeight + 'px';
+                    }
+                });
+
+                return accordionItem;
+            }
+
+            // Busca e agrupa (idêntico ao seu comportamento anterior)
+            function buscarEAgruparAgendamentos() {
+                const params = getFilters();
+                const url = `/professor/consultar-agendamento/buscar?${params.toString()}`;
+
+                accordionContainer.innerHTML = `
+                    <div class="text-center p-4">
+                        <div class="spinner-border" role="status"><span class="visually-hidden">Loading...</span></div>
+                        <p class="mt-2">Carregando dados...</p>
+                    </div>`;
+
+                fetch(url)
+                    .then(response => {
+                        if (!response.ok) throw new Error('Erro na resposta da rede.');
+                        return response.json();
+                    })
+                    .then(agendamentos => {
+                        const psicologos = {};
+
+                        agendamentos.forEach(ag => {
+                            if (!ag.ID_PSICOLOGO || !ag.paciente) return;
+
+                            if (!psicologos[ag.ID_PSICOLOGO]) {
+                                psicologos[ag.ID_PSICOLOGO] = {
+                                    id: ag.ID_PSICOLOGO,
+                                    nome: 'Psicólogo não identificado',
+                                    pacientes: [],
+                                    pacientes_ids: new Set()
+                                };
+                            }
+
+                            if (ag.psicologo && ag.psicologo.NOME_COMPL) {
+                                psicologos[ag.ID_PSICOLOGO].nome = ag.psicologo.NOME_COMPL;
+                            }
+
+                            if (!psicologos[ag.ID_PSICOLOGO].pacientes_ids.has(ag.paciente.ID_PACIENTE)) {
+                                psicologos[ag.ID_PSICOLOGO].pacientes.push({
+                                    nome: ag.paciente.NOME_COMPL_PACIENTE,
+                                    cpf: ag.paciente.CPF_PACIENTE || 'Não informado'
+                                });
+                                psicologos[ag.ID_PSICOLOGO].pacientes_ids.add(ag.paciente.ID_PACIENTE);
+                            }
+                        });
+
+                        accordionContainer.innerHTML = '';
+                        const psicologosArray = Object.values(psicologos);
+
+                        if (psicologosArray.length === 0) {
+                            accordionContainer.innerHTML = `
+                                <div class="text-center p-4">
+                                    <p class="text-muted">Nenhum resultado encontrado para os filtros aplicados.</p>
+                                </div>`;
+                            return;
+                        }
+
+                        psicologosArray.forEach(psicologo => {
+                            const item = montarItem(psicologo);
+                            accordionContainer.appendChild(item);
+                        });
+                    })
+                    .catch(error => {
+                        console.error('Erro ao buscar ou agrupar dados:', error);
+                        accordionContainer.innerHTML = `
+                            <div class="text-center p-4">
+                                <p class="text-danger">Falha ao carregar os dados. Tente novamente.</p>
+                            </div>`;
+                    });
+            }
+
+            searchForm.addEventListener('submit', (e) => {
+                e.preventDefault();
+                buscarEAgruparAgendamentos();
+            });
+
+            document.getElementById('btnClearFilters').addEventListener('click', () => {
+                searchForm.reset();
+                buscarEAgruparAgendamentos();
+            });
+
+            // Pequena função de escape para evitar injeção HTML com dados vindos do backend
+            function escapeHtml(str) {
+                if (str === null || str === undefined) return '';
+                return String(str)
+                    .replace(/&/g, '&amp;')
+                    .replace(/</g, '&lt;')
+                    .replace(/>/g, '&gt;')
+                    .replace(/"/g, '&quot;')
+                    .replace(/'/g, '&#39;');
+            }
+
+            // Primeira carga
+            buscarEAgruparAgendamentos();
+        });
+    </script>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -38,10 +38,6 @@ Route::middleware([AuthMiddleware::class, CheckClinicaMiddleware::class])->prefi
         return view('odontologia/menu_agenda', compact('usuario'));
     })->name('menu_agenda_odontologia');
 
-    Route::get('/usuarios', function () {
-        return view('odontologia/usuarios');
-    })->name('usuarios_odontologia');
-
     Route::get('/relatorio', function () {
         return view('odontologia/report_agenda');
     })->name('relatorio_odontologia');
@@ -58,40 +54,28 @@ Route::middleware([AuthMiddleware::class, CheckClinicaMiddleware::class])->prefi
         return view('odontologia/create_service');
     })->name('criarservico_odontologia');
 
-    Route::get('/criarusuario', function () {
-        return view('odontologia/create_user');
-    })->name('criarusuario_odontologia');
+    Route::get('/criarbox', function () {
+        return view('odontologia/create_box');
+    })->name('criarbox_odontologia');
 
     Route::get('/criarboxdisciplina', function () {
         return view('odontologia/create_box_discipline');
     })->name('criarbox_disciplina_odontologia');
 });
 
-//USER
-
-Route::post('/odontologia/criarusuario', [OdontoCreateController::class, 'createBox'])->name('createBox');
-Route::get('/odontologia/criarusuario/{userId}', [OdontoCreateController::class, 'editUser'])->name('editUser');
-Route::put('/updateUser/{userId}', [OdontoUpdateController::class, 'updateUser'])->name('updateUser');
-
-
-//LOG
-Route::get('/odontologia/pacientes/{id}/audits', [OdontoCreateController::class, 'historyPaciente'])->name('pacientes.audit');
-
 // CRIAÇÃO E EDIÇÃO - PACIENTE
 Route::get('/odontologia/criarpaciente', [OdontoCreateController::class, 'showForm'])->name('criarpaciente');
 Route::get('/odontologia/criarpaciente/{pacienteId}', [OdontoCreateController::class, 'editPatient'])->name('editPatient');
 Route::post('/odontologia/criarpaciente', [OdontoCreateController::class, 'fCreatePatient'])->name('createPatient');
 Route::put('/updatePatient/{id}', [OdontoUpdateController::class, 'updatePatient'])->name('updatePatient');
-Route::post('/odontologia/criarusuario', [OdontoCreateController::class, 'createUsuario'])->name('createUsuario');
-Route::put('/updateUser/{id}', [OdontoUpdateController::class, 'updateUser'])->name('updateUser');
 
 // SERVIÇOS
 Route::get('/odontologia/criarservico', function () {
     return view('odontologia/create_service');
 })->name('criarservico');
-Route::post('/odontologia/criarservico', [OdontoCreateController::class, 'createProcedures'])->name('createProcedures');
+Route::post('/odontologia/criarservico', [OdontoCreateController::class, 'createService'])->name('createService');
 Route::get('/criarservico/{idService}', [OdontoCreateController::class, 'editService'])->name('editService');
-Route::put('/criarservico/{idService}', [OdontoUpdateController::class, 'updateProcedures'])->name('updateProcedures');
+Route::put('/criarservico/{idService}', [OdontoUpdateController::class, 'updateService'])->name('updateService');
 
 // BOXES
 Route::get('/odontologia/criarbox', function () {
@@ -112,43 +96,28 @@ Route::post('/odontologia/criaragenda', [OdontoCreateController::class, 'fCreate
 Route::get('/odontologia/criaragenda/{agendaId}', [OdontoCreateController::class, 'editAgenda'])->name('editAgenda');
 Route::put('/updateAgenda/{id}', [OdontoUpdateController::class, 'updateAgenda'])->name('updateAgenda');
 
-//PERFIL
-
-Route::get('/perfil', [LoginController::class, 'login']);
-
 // CONSULTAS
 Route::get('/odontologia/agendamentos', [OdontoConsultController::class, 'getAgendamentos']);
-Route::get('/odontologia/disciplinascombox/', [OdontoConsultController::class, 'disciplinascombox']);
-Route::get('/getBoxDisciplines/{discipline}', [OdontoConsultController::class, 'boxesDisciplina']);
-Route::get('/procedimentos', [OdontoConsultController::class, 'procedimento']);
-Route::get('/odontologia/turmas/', [OdontoConsultController::class, 'getTodasTurmas']);
-Route::get('/getHorariosBoxDisciplinas/{discipline}', [OdontoConsultController::class, 'getHorariosBoxDisciplinas']);
-Route::get('/odontologia/disciplinas/', [OdontoConsultController::class, 'getDisciplinas']);
-Route::get('/odontologia/turmas', [OdontoConsultController::class, 'getTurmas']);
-Route::get('/odontologia/datas/{disciplina}/{turma}', [OdontoConsultController::class, 'getDatasTurmaDisciplina']);
-Route::get('/odontologia/horarios/{disciplina}/{turma}/{diasemana}', [OdontoConsultController::class, 'getHorariosDatasTurmaDisciplina']);
+Route::get('/odontologia/disciplinas', [OdontoConsultController::class, 'getDisciplinas']);
 Route::get('/odontologia/boxes', [OdontoConsultController::class, 'getBoxes']);
 Route::get('/odontologia/boxes/{boxId}', [OdontoConsultController::class, 'getBoxesId']);
-Route::get('/odontologia/user/{userId}', [OdontoConsultController::class, 'getUserId']);
 Route::get('/odontologia/boxeservicos/{servicoId}', [OdontoConsultController::class, 'getBoxeServicos']);
 Route::get('/getPacientes', [OdontoConsultController::class, 'buscarPacientes']);
-Route::get('/getProcedures', [OdontoConsultController::class, 'buscarProcedimentos']);
+Route::get('/getServices', [OdontoConsultController::class, 'buscarServicos']);
 Route::get('/getAgenda', [OdontoConsultController::class, 'buscarAgendamentos']);
 Route::get('/getBoxes', [OdontoConsultController::class, 'buscarBoxes']);
-Route::get('/getUser', [OdontoConsultController::class, 'buscarUsuarios']);
-Route::get('/getUserLyceum', [OdontoConsultController::class, 'buscarUsuariosLyceum']);
-Route::get('/getUserLyceum/{pessoa}', [OdontoConsultController::class, 'buscarPessoaLyceum']);
 Route::get('/getBoxDisciplines', [OdontoConsultController::class, 'buscarBoxeDisciplinas']);
+Route::get('/getBoxDisciplines/{discipline}', [OdontoConsultController::class, 'boxesDisciplina']);
 Route::get('/consultaboxdisciplina/{idBoxDiscipline}', [OdontoConsultController::class, 'consultaboxdisciplina']);
 Route::get('/paciente/{pacienteId}', [OdontoConsultController::class, 'listaPacienteId']);
 Route::get('/servicos/{servicoId}', [OdontoConsultController::class, 'listaServicosId']);
+Route::get('/servicos', [OdontoConsultController::class, 'services']);
 Route::get('/agenda/{pacienteId}', [OdontoConsultController::class, 'listaAgendamentoId']);
 
 // CONSULTA DE VIEWS
 Route::get('/odontologia/consultarpaciente', [OdontoConsultController::class, 'fSelectPatient'])->name('selectPatient');
 Route::get('/odontologia/consultarservico', [OdontoConsultController::class, 'fSelectService'])->name('selectService');
 Route::get('/odontologia/consultarbox', [OdontoConsultController::class, 'fSelectBox'])->name('selectBox');
-Route::get('/odontologia/consultarusuario', [OdontoConsultController::class, 'selectUser'])->name('selectUser');
 Route::get('/odontologia/consultardisciplinabox', [OdontoConsultController::class, 'fSelectBoxDiscipline'])->name('selectBoxDiscipline');
 Route::get('/odontologia/consultaragenda', [OdontoConsultController::class, 'fSelectAgenda'])->name('selectAgenda');
 
@@ -160,19 +129,12 @@ Route::post('/definelocalatendimento/{agendaId,boxId}', [OdontoCreateController:
 Route::get('/consultarpaciente', function () {
     return view('odontologia/consult_patient');
 })->name('consultarpaciente');
-
 Route::get('/consultarservico', function () {
     return view('odontologia/consult_servico');
 })->name('consultarservico');
-
 Route::get('/consultarbox', function () {
     return view('odontologia/consult_box');
 })->name('consultarbox');
-
-Route::get('/consultarusuario', function () {
-    return view('odontologia/consult_user');
-})->name('consultarusuario');
-
 Route::get('/consultardisciplinabox', function () {
     return view('odontologia/consult_box_discipline');
 })->name('consultardisciplinabox');
@@ -219,7 +181,7 @@ Route::get('/', function () {
 })->name('loginGET');
 
 Route::get('/selecionar-clinica', function () {
-    if (session()->has('usuario')) {
+    if(session()->has('usuario')) {
         return view('selecionar_clinica');
     } else {
         return redirect()->route('loginGET');
@@ -237,7 +199,7 @@ Route::middleware([AuthMiddleware::class])->group(function () {
 
     Route::post('/login', [LoginController::class, 'login'])->name('loginPOST');
 
-    Route::get('/logout', function () {
+    Route::get('/logout', function() {
         session()->forget('usuario');
         return redirect()->route('loginGET');
     })->name('logout');
@@ -249,222 +211,133 @@ Route::middleware([AuthMiddleware::class, CheckClinicaMiddleware::class])
     ->prefix('psicologia')
     ->group(function () {
 
-        // ROOT
-        Route::get('/', function () {
-            $usuario = session('usuario');
-            return view('psicologia.adm/menu_agenda', compact('usuario'));
-        })->name('menu_agenda_psicologia');
+    // ROOT
+    Route::get('/', function () {
+        $usuario = session('usuario');
+        return view('psicologia.adm/menu_agenda', compact('usuario'));
+    })->name('menu_agenda_psicologia');
 
-        // RELATÓRIOS
-        Route::get('/relatorios-agendamento', function () {
-            return view('psicologia.adm/relatorios_agendamento');
-        })->name('relatorio_psicologia');
+    // RELATÓRIOS
+    Route::get('/relatorios-agendamento', function () {
+        return view('psicologia.adm/relatorios_agendamento');
+    })->name('relatorio_psicologia');
 
-        // CRIAR PACIENTE
-        Route::get('/criar-paciente', function () {
-            return view('psicologia.adm/criar_paciente');
-        })->name('criarpaciente_psicologia');
-        Route::post('/criar-paciente/criar', [PacienteController::class, 'createPaciente'])->name('criarPaciente-Psicologia');
+    // CRIAR PACIENTE
+    Route::get('/criar-paciente', function () {
+        return view('psicologia.adm/criar_paciente');
+    })->name('criarpaciente_psicologia');
+    Route::post('/criar-paciente/criar', [PacienteController::class, 'createPaciente'])->name('criarPaciente-Psicologia');
 
-        // EDITAR PACIENTE
-        Route::get('/editar-paciente', function () {
-            return view('psicologia.adm/editar_paciente');
-        })->name('editarPacienteView-Psicologia');
-        Route::post('/editar-paciente/{id}', [PacienteController::class, 'editarPaciente'])->name('editarPaciente-Psicologia');
+    // EDITAR PACIENTE
+    Route::get('/editar-paciente', function () {
+        return view('psicologia.adm/editar_paciente');
+    })->name('editarPacienteView-Psicologia');
+    Route::post('/editar-paciente/{id}', [PacienteController::class, 'editarPaciente'])->name('editarPaciente-Psicologia');
 
-        // API BUSCAR PACIENTES
-        Route::get('/api/buscar-pacientes', function () {
-            $query = request()->input('query', '');
-            $pacientes = FaesaClinicaPaciente::where(function ($q) use ($query) {
+    // API BUSCAR PACIENTES
+    Route::get('/api/buscar-pacientes', function () {
+        $query = request()->input('query', '');
+        $pacientes = FaesaClinicaPaciente::where(function ($q) use ($query) {
                 $q->where('NOME_COMPL_PACIENTE', 'like', "%{$query}%")
-                    ->orWhere('CPF_PACIENTE', 'like', "%{$query}%");
+                  ->orWhere('CPF_PACIENTE', 'like', "%{$query}%");
             })
-                ->limit(10)
-                ->get(['ID_PACIENTE', 'NOME_COMPL_PACIENTE', 'CPF_PACIENTE']);
+            ->limit(10)
+            ->get(['ID_PACIENTE', 'NOME_COMPL_PACIENTE', 'CPF_PACIENTE']);
 
-            return response()->json($pacientes);
-        });
-
-        // CONSULTAR PACIENTE
-        Route::get('/consultar-paciente', function () {
-            return view('psicologia.adm.consultar_paciente');
-        })->name('consultar-paciente');
-        Route::get('/consultar-paciente/buscar', [PacienteController::class, 'getPaciente'])->name('getPaciente');
-        Route::get('/paciente/{id}/ativar', [PacienteController::class, 'setAtivo'])->name('ativarPaciente-Psicologia');
-        Route::delete('/excluir-paciente/{id}', [PacienteController::class, 'deletePaciente'])->name('deletePaciente-Psicologia');
-
-        // AGENDAMENTOS
-        Route::get('/criar-agendamento', function () {
-            return view('psicologia.adm/criar_agenda');
-        })->name('criaragenda_psicologia');
-        Route::post('/criar-agendamento/criar', [AgendamentoController::class, 'criarAgendamento'])->name('criarAgendamento-Psicologia');
-        Route::put('/agendamentos/{id}/status', [AgendamentoController::class, 'atualizarStatus']);
-        Route::put('/agendamentos/{id}/mensagem-cancelamento', [AgendamentoController::class, 'addMensagemCancelamento']);
-        Route::get('/consultar-agendamento', function () {
-            return view('psicologia.adm.consultar_agendamento');
-        })->name('listagem-agendamentos');
-        Route::post('/consultar-agendamento/consultar', [AgendamentoController::class, 'getAgendamento'])->name('getAgendamento');
-        Route::get('/get-agendamento', [AgendamentoController::class, 'getAgendamento']);
-        Route::get('/agendamentos/paciente/{id}', [AgendamentoController::class, 'getAgendamentosByPaciente']);
-        Route::get('/agendamento/{id}', [AgendamentoController::class, 'showAgendamento'])->name('agendamento.show');
-        Route::get('/agendamentos-calendar', [AgendamentoController::class, 'getAgendamentosForCalendar']);
-        Route::get('/agendamento/{id}/editar', [AgendamentoController::class, 'editAgendamento'])->name('agendamento.edit');
-        Route::put('/agendamento/{id}', [AgendamentoController::class, 'updateAgendamento'])->name('agendamento.update');
-        Route::delete('/agendamento/{id}', [AgendamentoController::class, 'deleteAgendamento'])->name('psicologia.agendamento.delete');
-
-        // PSICOLOGOS
-        Route::get('criar-psicologo', function () {
-            return view('psicologia.adm.criar_psicologo');
-        })->name('psicologia.Criar_psicologo');
-
-        Route::post('criar-psicologo', [PsicologoController::class, 'createPsicologo'])->name('psicologia.Criar_psicologoPOST');
-
-        Route::get('consultar-psicologo', function () {
-            return view('psicologia.adm.consultar_psicologo');
-        })->name('psicologia.Consult_psicologo');
-
-        Route::get('buscar-aluno/{matricula}', [PsicologoController::class, 'listAlunos'])->name('listAlunos-Psicologia');
-
-        // PROFESSORES
-        Route::get('criar-professor', function () {
-            return view('psicologia.adm.criar_professor');
-        })->name('psicologia.CriarProfessor');
-
-        Route::get('consultar-professor', function () {
-            return view('psicologia.adm.consultar_professor');
-        })->name('psicologia.COnsult_professor');
-
-        // SERVIÇOS
-        Route::get('/criar-servico', function () {
-            return view('psicologia.adm/criar_servico');
-        })->name('criarservico_psicologia');
-        Route::post('/criar-servico/criar', [ServicoController::class, 'criarServico'])->name('criarServico-Psicologia');
-        Route::get('/pesquisar-servico', [ServicoController::class, 'getServicos'])->name('pesquisarServico-Psicologia');
-        Route::get('/api/buscar-servicos', function () {
-            $query = request()->input('query', '');
-            $servicos = FaesaClinicaServico::where('SERVICO_CLINICA_DESC', 'like', "%{$query}%")
-                ->where('ID_CLINICA', 1)
-                ->limit(10)
-                ->get(['ID_SERVICO_CLINICA', 'SERVICO_CLINICA_DESC']);
-
-            return response()->json($servicos);
-        });
-        Route::get('/servicos', [ServicoController::class, 'getServicos']);
-        Route::get('/servicos/{id}', [ServicoController::class, 'getServicoById']);
-        Route::post('/servicos', [ServicoController::class, 'criarServico']);
-        Route::put('/servicos/{id}', [ServicoController::class, 'atualizarServico']);
-        Route::delete('/servicos/{id}', [ServicoController::class, 'deletarServico']);
-
-        // SALAS
-        Route::get('/criar-sala', function () {
-            return view('psicologia.adm.criar_sala');
-        })->name('salas_psicologia');
-        Route::post('/salas/criar', [SalaController::class, 'createSala'])->name('criarSala-Psicologia');
-        Route::get('/salas/listar', [SalaController::class, 'listSalas'])->name('listarSalas-Psicologia');
-        Route::put('/salas/{id}', [SalaController::class, 'updateSala'])->name('atualizarSala-Psicologia');
-        Route::get('/pesquisar-local', [SalaController::class, 'getSala'])->name('pesquisarLocal-Psicologia');
-
-        // HORÁRIOS
-        Route::get('/criar-horario', function () {
-            return view('psicologia.adm.criar_horario');
-        })->name('criarHorarioView-Psicologia');
-        Route::post('/horarios/criar-horario', [HorarioController::class, 'createHorario'])->name('criarHorario-Psicologia');
-        Route::get('/horarios/listar', [HorarioController::class, 'listHorarios'])->name('listarHorarios-Psicologia');
-        Route::put('/horarios/atualizar/{id}', [HorarioController::class, 'updateHorario'])->name('updateHorario-Psicologia');
-        Route::delete('/horarios/deletar/{id}', [HorarioController::class, 'deleteHorario'])->name('deleteHorario-Psicologia');
-
-        // BUSCA DE DISCIPLINAS PARA VINCULAR AO SERVIÇO
-        Route::get('/disciplinas-psicologia', [DisciplinaController::class, 'getDisciplina']);
+        return response()->json($pacientes);
     });
 
-// CONSULTAR PACIENTE
-Route::get('/consultar-paciente', function () {
-    return view('psicologia.adm.consultar_paciente');
-})->name('consultar-paciente');
-Route::get('/consultar-paciente/buscar', [PacienteController::class, 'getPaciente'])->name('getPaciente');
-Route::get('/consultar-paciente/buscar-nome-cpf', [PacienteController::class, 'getPacienteByNameCpf'])->name('getPacienteByNameCpf');
-Route::get('/paciente/{id}/ativar', [PacienteController::class, 'setAtivo'])->name('ativarPaciente-Psicologia');
-Route::delete('/excluir-paciente/{id}', [PacienteController::class, 'deletePaciente'])->name('deletePaciente-Psicologia');
+    // CONSULTAR PACIENTE
+    Route::get('/consultar-paciente', function () {
+        return view('psicologia.adm.consultar_paciente');
+    })->name('consultar-paciente');
+    Route::get('/consultar-paciente/buscar', [PacienteController::class, 'getPaciente'])->name('getPaciente');
+    Route::get('/consultar-paciente/buscar-nome-cpf', [PacienteController::class, 'getPacienteByNameCpf'])->name('getPacienteByNameCpf');
+    Route::get('/paciente/{id}/ativar', [PacienteController::class, 'setAtivo'])->name('ativarPaciente-Psicologia');
+    Route::delete('/excluir-paciente/{id}', [PacienteController::class, 'deletePaciente'])->name('deletePaciente-Psicologia');
 
-// AGENDAMENTOS
-Route::get('/criar-agendamento', function () {
-    return view('psicologia.adm/criar_agenda');
-})->name('criaragenda_psicologia');
-Route::post('/criar-agendamento/criar', [AgendamentoController::class, 'criarAgendamento'])->name('criarAgendamento-Psicologia');
-Route::put('/agendamentos/{id}/status', [AgendamentoController::class, 'atualizarStatus']);
-Route::put('/agendamentos/{id}/mensagem-cancelamento', [AgendamentoController::class, 'addMensagemCancelamento']);
-Route::get('/consultar-agendamento', function () {
-    return view('psicologia.adm.consultar_agendamento');
-})->name('listagem-agendamentos');
-Route::post('/consultar-agendamento/consultar', [AgendamentoController::class, 'getAgendamento'])->name('getAgendamento');
-Route::get('/get-agendamento', [AgendamentoController::class, 'getAgendamento']);
-Route::get('/agendamentos/paciente/{id}', [AgendamentoController::class, 'getAgendamentosByPaciente']);
-Route::get('/agendamento/{id}', [AgendamentoController::class, 'showAgendamento'])->name('agendamento.show');
-Route::get('/agendamentos-calendar/adm', [AgendamentoController::class, 'getAgendamentosForCalendar']);
-Route::get('/agendamento/{id}/editar', [AgendamentoController::class, 'editAgendamento'])->name('agendamento.edit');
-Route::put('/agendamento', [AgendamentoController::class, 'updateAgendamento'])->name('agendamento.update');
-Route::delete('/agendamento/{id}', [AgendamentoController::class, 'deleteAgendamento'])->name('psicologia.agendamento.delete');
+    // AGENDAMENTOS
+    Route::get('/criar-agendamento', function () {
+        return view('psicologia.adm/criar_agenda');
+    })->name('criaragenda_psicologia');
+    Route::post('/criar-agendamento/criar', [AgendamentoController::class, 'criarAgendamento'])->name('criarAgendamento-Psicologia');
+    Route::put('/agendamentos/{id}/status', [AgendamentoController::class, 'atualizarStatus']);
+    Route::put('/agendamentos/{id}/mensagem-cancelamento', [AgendamentoController::class, 'addMensagemCancelamento']);
+    Route::get('/consultar-agendamento', function () {
+        return view('psicologia.adm.consultar_agendamento');
+    })->name('listagem-agendamentos');
+    Route::post('/consultar-agendamento/consultar', [AgendamentoController::class, 'getAgendamento'])->name('getAgendamento');
+    Route::get('/get-agendamento', [AgendamentoController::class, 'getAgendamento']);
+    Route::get('/agendamentos/paciente/{id}', [AgendamentoController::class, 'getAgendamentosByPaciente']);
+    Route::get('/agendamento/{id}', [AgendamentoController::class, 'showAgendamento'])->name('agendamento.show');
+    Route::get('/agendamentos-calendar/adm', [AgendamentoController::class, 'getAgendamentosForCalendar']);
+    Route::get('/agendamento/{id}/editar', [AgendamentoController::class, 'editAgendamento'])->name('agendamento.edit');
+    Route::put('/agendamento', [AgendamentoController::class, 'updateAgendamento'])->name('agendamento.update');
+    Route::delete('/agendamento/{id}', [AgendamentoController::class, 'deleteAgendamento'])->name('psicologia.agendamento.delete');
 
-Route::get('buscar-aluno/{matricula}', [PsicologoController::class, 'listAlunos'])->name('listAlunos-Psicologia');
+    Route::get('buscar-aluno/{matricula}', [PsicologoController::class, 'listAlunos'])->name('listAlunos-Psicologia');
 
-// SERVIÇOS
-Route::get('/criar-servico', function () {
-    return view('psicologia.adm/criar_servico');
-})->name('criarservico_psicologia');
-Route::post('/criar-servico/criar', [ServicoController::class, 'criarServico'])->name('criarServico-Psicologia');
-Route::get('/pesquisar-servico', [ServicoController::class, 'getServicos'])->name('pesquisarServico-Psicologia');
-Route::get('/api/buscar-servicos', function () {
-    $query = request()->input('query', '');
-    $servicos = FaesaClinicaServico::where('SERVICO_CLINICA_DESC', 'like', "%{$query}%")
-        ->where('ID_CLINICA', 1)
-        ->limit(10)
-        ->get(['ID_SERVICO_CLINICA', 'SERVICO_CLINICA_DESC']);
+    // SERVIÇOS
+    Route::get('/criar-servico', function () {
+        return view('psicologia.adm/criar_servico');
+    })->name('criarservico_psicologia');
+    Route::post('/criar-servico/criar', [ServicoController::class, 'criarServico'])->name('criarServico-Psicologia');
+    Route::get('/pesquisar-servico', [ServicoController::class, 'getServicos'])->name('pesquisarServico-Psicologia');
+    Route::get('/api/buscar-servicos', function () {
+        $query = request()->input('query', '');
+        $servicos = FaesaClinicaServico::where('SERVICO_CLINICA_DESC', 'like', "%{$query}%")
+            ->where('ID_CLINICA', 1)
+            ->limit(10)
+            ->get(['ID_SERVICO_CLINICA', 'SERVICO_CLINICA_DESC']);
 
-    return response()->json($servicos);
+        return response()->json($servicos);
+    });
+    Route::get('/servicos', [ServicoController::class, 'getServicos']);
+    Route::get('/servicos/{id}', [ServicoController::class, 'getServicoById']);
+    Route::post('/servicos', [ServicoController::class, 'criarServico']);
+    Route::put('/servicos/{id}', [ServicoController::class, 'atualizarServico']);
+    Route::delete('/servicos/{id}', [ServicoController::class, 'deletarServico']);
+
+    // SALAS
+    Route::get('/criar-sala', function () {
+        return view('psicologia.adm.criar_sala');
+    })->name('salas_psicologia');
+    Route::post('/salas/criar', [SalaController::class, 'createSala'])->name('criarSala-Psicologia');
+    Route::get('/salas/listar', [SalaController::class, 'listSalas'])->name('listarSalas-Psicologia');
+    Route::put('/salas/{id}', [SalaController::class, 'updateSala'])->name('atualizarSala-Psicologia');
+    Route::get('/pesquisar-local', [SalaController::class, 'getSala'])->name('pesquisarLocal-Psicologia');
+    Route::delete('salas/{id}', [SalaController::class, 'deleteSala'])->name('deleteSala-Psicologia');
+
+    // HORÁRIOS
+    Route::get('/criar-horario', function () {
+        return view('psicologia.adm.criar_horario');
+    })->name('criarHorarioView-Psicologia');
+    Route::post('/horarios/criar-horario', [HorarioController::class, 'createHorario'])->name('criarHorario-Psicologia');
+    Route::get('/horarios/listar', [HorarioController::class, 'listHorarios'])->name('listarHorarios-Psicologia');
+    Route::put('/horarios/atualizar/{id}', [HorarioController::class, 'updateHorario'])->name('updateHorario-Psicologia');
+    Route::delete('/horarios/deletar/{id}', [HorarioController::class, 'deleteHorario'])->name('deleteHorario-Psicologia');
+
+    // BUSCA DE DISCIPLINAS PARA VINCULAR AO SERVIÇO
+    Route::get('/disciplinas-psicologia', [DisciplinaController::class, 'getDisciplina']);
+    Route::get('/disciplina/{codigo}', [DisciplinaController::class, 'getDisciplinaByCodigo'])->name('getDisciplinaByCodigo');
+
+    Route::get('/listar-psicologos', [PsicologoController::class, 'listAlunos']);
 });
-Route::get('/servicos', [ServicoController::class, 'getServicos']);
-Route::get('/servicos/{id}', [ServicoController::class, 'getServicoById']);
-Route::post('/servicos', [ServicoController::class, 'criarServico']);
-Route::put('/servicos/{id}', [ServicoController::class, 'atualizarServico']);
-Route::delete('/servicos/{id}', [ServicoController::class, 'deletarServico']);
 
-// SALAS
-Route::get('/criar-sala', function () {
-    return view('psicologia.adm.criar_sala');
-})->name('salas_psicologia');
-Route::post('/salas/criar', [SalaController::class, 'createSala'])->name('criarSala-Psicologia');
-Route::get('/salas/listar', [SalaController::class, 'listSalas'])->name('listarSalas-Psicologia');
-Route::put('/salas/{id}', [SalaController::class, 'updateSala'])->name('atualizarSala-Psicologia');
-Route::get('/pesquisar-local', [SalaController::class, 'getSala'])->name('pesquisarLocal-Psicologia');
-Route::delete('salas/{id}', [SalaController::class, 'deleteSala'])->name('deleteSala-Psicologia');
 
-// HORÁRIOS
-Route::get('/criar-horario', function () {
-    return view('psicologia.adm.criar_horario');
-})->name('criarHorarioView-Psicologia');
-Route::post('/horarios/criar-horario', [HorarioController::class, 'createHorario'])->name('criarHorario-Psicologia');
-Route::get('/horarios/listar', [HorarioController::class, 'listHorarios'])->name('listarHorarios-Psicologia');
-Route::put('/horarios/atualizar/{id}', [HorarioController::class, 'updateHorario'])->name('updateHorario-Psicologia');
-Route::delete('/horarios/deletar/{id}', [HorarioController::class, 'deleteHorario'])->name('deleteHorario-Psicologia');
-
-// BUSCA DE DISCIPLINAS PARA VINCULAR AO SERVIÇO
-Route::get('/disciplinas-psicologia', [DisciplinaController::class, 'getDisciplina']);
-Route::get('/disciplina/{codigo}', [DisciplinaController::class, 'getDisciplinaByCodigo'])->name('getDisciplinaByCodigo');
-
-Route::get('/listar-psicologos', [PsicologoController::class, 'listAlunos']);
 
 
 // ROTAS DE PSICÓLOGO
-Route::get('/psicologo/login', function () {
-    if (session()->has('psicologo')) {
+Route::get('/psicologo/login', function() {
+    if(session()->has('psicologo')) {
         return redirect()->route('psicologoAgenda');
     } else {
         return view('psicologia.psicologo.login_psicologo');
     }
-});
+})->name('psicologoLoginGet');
 
-Route::get('/psicologo', function () {
-    if (session()->has('psicologo')) {
+Route::get('/psicologo', function() {
+    if(session()->has('psicologo')) {
         return view(view: 'psicologia.psicologo.menu_agenda');
     } else {
         return redirect()->route('psicologoLoginGet');
@@ -472,19 +345,12 @@ Route::get('/psicologo', function () {
 })->name('psicologoAgenda');
 
 Route::middleware([AuthPsicologoMiddleware::class])->group(function () {
-    Route::post('/psicologo/login', function () {
-
+    Route::post('/psicologo/login', function() {
         return redirect()->route('psicologoAgenda');
         // return view('psicologia.psicologo.menu_agenda');
     })->name('psicologoLoginPost');
 
     Route::get('/psicologo/agendamentos-calendar', [AgendamentoController::class, 'getAgendamentosForCalendarPsicologo']);
-
-
-    Route::get('/psicologo/logout', function () {
-        session()->flush();
-        return redirect()->route('psicologoLoginGet');
-    })->name('psicologoLogout');
 
     Route::get('/psicologo/consultar-paciente/buscar', [PacienteController::class, 'getPacienteByNameCPFPsicologo'])->name('psicologoGetPaciente');
 
@@ -494,72 +360,63 @@ Route::middleware([AuthPsicologoMiddleware::class])->group(function () {
 
     Route::get('/psicologo/pesquisar-disciplina', [ServicoController::class, 'getDisciplinaServico'])->name('psicologoGetDisciplina');
 
-    Route::get('/psicologo/criar-agendamento', function () {
+    Route::get('/psicologo/criar-agendamento', function() {
         return view('psicologia.psicologo.criar_agenda');
     })->name('psicologoCriarAgenda-Get');
 
     Route::post('/psicologo/criar-agendamento/criar', [AgendamentoController::class, 'criarAgendamentoPsicologo'])->name('criarAgendamento-Psicologo');
 
-    Route::get('/psicologo/consultar-agendamento', function () {
+    Route::get('/psicologo/consultar-agendamento', function() {
         return view('psicologia.psicologo.consultar_agenda');
     })->name('psicologoConsultarAgendamentos-GET');
 });
-Route::get('/psicologo/logout', function () {
+Route::get('/psicologo/logout', function() {
     session()->forget('psicologo');
     return redirect()->route('psicologoLoginGet');
 })->name('psicologoLogout');
 
+
+
+
+
 // ROTAS DE PROFESSOR
-Route::get('/professor/login', function () {
-    if (session()->has('professor')) {
+Route::get('/professor/login', function() {
+    if(session()->has('professor')) {
         return view('psicologia.professor.menu_agenda');
     } else {
         return view('psicologia.professor.login_professor');
     }
 })->name('professorLoginGet');
 
-Route::post('/professor/login', function () {
-    if (session()->has('professor')) {
+Route::post('/professor/login', function() {
+    if(session()->has('professor')) {
         return view('psicologia.professor.menu_agenda');
     }
 })->name('professorLoginPost');
 
-
-Route::middleware([AuthMiddleware::class])->group(function () {
-
-    Route::match(['get', 'post'], '/professor', function () {
+Route::middleware([AuthProfessorMiddleware::class])->group( function() {
+    Route::match(['get', 'post'], '/professor', function() {
         return view('psicologia.professor.menu_agenda');
     })->name('professorMenu');
 
-    Route::post('/professor/login', function () {
+    Route::get('/professor/agendamentos-calendar', [AgendamentoController::class, 'getAgendamentosForCalendarProfessor'])->name('getAgendamentosForCalendarProfessor');
+
+    Route::post('/professor/login', function() {
         return view('psicologia.professor.menu_agenda');
     })->name('professorLoginPost');
 
-    Route::get('/professor/logout', function () {
-        session()->flush();
+    Route::get('/professor/consultar-agendamento', function() {
+        return view('psicologia.professor.consultar_agenda');
+    })->name('professorConsultarAgendamentos-GET');
 
-        Route::middleware([AuthProfessorMiddleware::class])->group(function () {
-            Route::match(['get', 'post'], '/professor', function () {
-                return view('psicologia.professor.menu_agenda');
-            })->name('professorMenu');
+    Route::get('/professor/consultar-agendamento/buscar', [AgendamentoController::class, 'getAgendamentosForProfessor'])->name('getAgendamentosForProfessor');
 
-            Route::get('/professor/agendamentos-calendar', [AgendamentoController::class, 'getAgendamentosForCalendarProfessor'])->name('getAgendamentosForCalendarProfessor');
-
-            Route::post('/professor/login', function () {
-                return view('psicologia.professor.menu_agenda');
-            })->name('professorLoginPost');
-
-            Route::get('/professor/consultar-agendamento', function () {
-                return view('psicologia.professor.consultar_agenda');
-            })->name('professorConsultarAgendamentos-GET');
-
-            Route::get('/professor/consultar-agendamento/buscar', [AgendamentoController::class, 'getAgendamentosForProfessor'])->name('getAgendamentosForProfessor');
-
-            Route::get('/professor/logout', function () {
-                session()->forget('professor');
-
-                return redirect()->route('professorLoginGet');
-            })->name('professorLogout');
-        });
+    Route::get('/professor/psicologo', function() {
+        return view('psicologia.professor.consultar_psicologo');
     });
+
+    Route::get('/professor/logout', function() {
+        session()->forget('professor');
+        return redirect()->route('professorLoginGet');
+    })->name('professorLogout');
 });


### PR DESCRIPTION
Simplifies and reorganizes route definitions for professor and psicologo roles. Updates navbar to add direct psicologo access and removes redundant patient listing. Unifies calendar and agendamento routes, improves naming consistency, and removes deprecated or duplicate endpoints for users and services. Enhances maintainability and navigation for psychology-related features.